### PR TITLE
Continue on error

### DIFF
--- a/script.py
+++ b/script.py
@@ -10,9 +10,11 @@ from mutagen.mp4 import MP4
 # --- Configuration ---
 SRC_DIR = Path('.')          # directory containing your .jpg and .mp4 files
 OUT_DIR = SRC_DIR / 'out'    # destination subfolder
+FAIL_DIR = SRC_DIR / 'failed' # folder for files that fail to process
 
-# Create output directory if it doesn't exist
+# Create output and failed directories if they don't exist
 OUT_DIR.mkdir(exist_ok=True)
+FAIL_DIR.mkdir(exist_ok=True)
 
 # Regex to capture date prefix: YYYY-MM-DD
 DATE_RE = re.compile(r'^(?P<date>\d{4}-\d{2}-\d{2})_')
@@ -22,31 +24,41 @@ def process_jpg(src_path: Path, date_str: str):
     Copy JPEG to out/ and set the EXIF DateTimeOriginal tag to date_str.
     """
     dst_path = OUT_DIR / src_path.name
-    shutil.copy2(src_path, dst_path)
+    fail_path = FAIL_DIR / src_path.name
     
-    # Prepare EXIF payload
-    exif_dict = piexif.load(str(dst_path))
-    # Format required by EXIF: "YYYY:MM:DD HH:MM:SS"
-    dt_value = date_str.replace('-', ':') + " 00:00:00"
-    exif_dict["Exif"][piexif.ExifIFD.DateTimeOriginal] = dt_value.encode('utf-8')
+    try:
+        shutil.copy2(src_path, dst_path)
+        # Prepare EXIF payload
+        exif_dict = piexif.load(str(dst_path))
+        # Format required by EXIF: "YYYY:MM:DD HH:MM:SS"
+        dt_value = date_str.replace('-', ':') + " 00:00:00"
+        exif_dict["Exif"][piexif.ExifIFD.DateTimeOriginal] = dt_value.encode('utf-8')
+        
+        # Insert updated EXIF back into file
+        exif_bytes = piexif.dump(exif_dict)
+        piexif.insert(exif_bytes, str(dst_path))
+        print(f"[JPEG]  {src_path.name} → out/{dst_path.name} (DateTimeOriginal={dt_value})")
+    except:
+        shutil.copy2(src_path, fail_path)
+        print(f"FAILED {src_path.name}")
     
-    # Insert updated EXIF back into file
-    exif_bytes = piexif.dump(exif_dict)
-    piexif.insert(exif_bytes, str(dst_path))
-    print(f"[JPEG]  {src_path.name} → out/{dst_path.name} (DateTimeOriginal={dt_value})")
-
 def process_mp4(src_path: Path, date_str: str):
     """
     Copy MP4 to out/ and set the ©day tag to date_str.
     """
     dst_path = OUT_DIR / src_path.name
-    shutil.copy2(src_path, dst_path)
+    fail_path = FAIL_DIR / src_path.name
     
-    mp4file = MP4(str(dst_path))
-    # The ©day atom stores the release/creation date as "YYYY-MM-DD"
-    mp4file["\xa9day"] = [date_str]
-    mp4file.save()
-    print(f"[MP4]   {src_path.name} → out/{dst_path.name} (©day={date_str})")
+    try:
+        shutil.copy2(src_path, dst_path)
+        mp4file = MP4(str(dst_path))
+        # The ©day atom stores the release/creation date as "YYYY-MM-DD"
+        mp4file["\xa9day"] = [date_str]
+        mp4file.save()
+        print(f"[MP4]   {src_path.name} → out/{dst_path.name} (©day={date_str})")
+    except:
+        shutil.copy2(src_path, fail_path)
+        print(f"FAILED {src_path.name}")
 
 def main():
     for entry in SRC_DIR.iterdir():


### PR DESCRIPTION
Wrapped the processing for photos and videos in a try/except statement so the script will continue working if it encounters an error. Files which fail to process are copied to a new `failed` directory similar to the `out` directory.